### PR TITLE
デバイス詳細画面から手動更新する時にハッシュのキーが間違っているのを直す

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ bundle install
 ### デバッグ
 * デバイス詳細webページのaction cable js channelに通知を送る
   * `ActionCable.server.broadcast(device.unique_key, { type: :loaded_config })`
+  * `ActionCable.server.broadcast(device.unique_key, { type: :device_is_active })`
+      * pingのレスポンス. デバイス詳細画面にあるモーダルのサブミットボタンがクリックできるようになる
 
 ### TODO
 * デバイス詳細ページをReactで作る

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -100,7 +100,7 @@ class DevicesController < ApplicationController
     setting_content = params[:setting_content]
     pbm_job = Admin::PbmJob::CreateRestorePbmSettingJobService.new(
       device: device,
-      setting_content: setting_content,
+      setting_content: { 'setting' => setting_content }, # TODO settingがnestしているの直す. clientの修正も必要?
       setting_name: 'manual input setting'
     ).execute!
     ActionCable.server.broadcast(device.push_token, PbmJobSerializer.new(pbm_job).attributes)

--- a/spec/requests/devices_spec.rb
+++ b/spec/requests/devices_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "Devices", type: :request do
     include_context "login_with_user"
 
     let(:device) { FactoryBot.create(:device, user: user, name: "bar") }
-    let(:saved_buttons_setting) { FactoryBot.create(:saved_buttons_setting, user: user, content: { a: 1 }) }
+    let(:saved_buttons_setting) { FactoryBot.create(:saved_buttons_setting, user: user) }
 
     subject { post restore_setting_device_path(device.unique_key, saved_buttons_setting_id: saved_buttons_setting.id, format: :js) }
 
@@ -227,9 +227,10 @@ RSpec.describe "Devices", type: :request do
     end
 
     it do
-      subject
+      expect { subject }.to change { device.pbm_jobs.count }.by(1)
       pbm_job = device.pbm_jobs.last
-      expect(pbm_job.args).to eq({ "setting" => {"a"=>1}, "setting_name" => "title2" })
+      expect(pbm_job.args['setting_name']).to eq("title2")
+      expect(pbm_job.args['setting']).to eq(saved_buttons_setting.content)
     end
 
     it do
@@ -259,7 +260,7 @@ RSpec.describe "Devices", type: :request do
     it do
       subject
       pbm_job = device.pbm_jobs.last
-      expect(pbm_job.args).to eq({ "setting" => {"a"=>'1'}, "setting_name" => "manual input setting" })
+      expect(pbm_job.args).to eq({ "setting" => { 'setting' => {"a"=>'1' } }, "setting_name" => "manual input setting" })
     end
 
     it do


### PR DESCRIPTION
clientに送信した時に起きたエラー

```
/home/pi/.rbenv/versions/3.0.1/lib/ruby/3.0.0/json/common.rb:216:in `initialize': no implicit conversion of nil into String (TypeError)
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/3.0.0/json/common.rb:216:in `new'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/3.0.0/json/common.rb:216:in `parse'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/blue_green_process-acbb05dcd4cf/lib/blue_green_process/master_process.rb:45:in `block (2 levels) in fork_process'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/blue_green_process-acbb05dcd4cf/lib/blue_green_process/master_process.rb:43:in `loop'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/blue_green_process-acbb05dcd4cf/lib/blue_green_process/master_process.rb:43:in `block in fork_process'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/blue_green_process-acbb05dcd4cf/lib/blue_green_process/master_process.rb:35:in `fork'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/blue_green_process-acbb05dcd4cf/lib/blue_green_process/master_process.rb:35:in `fork_process'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/blue_green_process-acbb05dcd4cf/lib/blue_green_process/master_process.rb:15:in `initialize'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/blue_green_process-acbb05dcd4cf/lib/blue_green_process.rb:28:in `new'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/blue_green_process-acbb05dcd4cf/lib/blue_green_process.rb:28:in `new'
        from /home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/procon_bypass_man-19bc751a490b/lib/procon_bypass_man/bypass/bypass_command.rb:61:in `block in execute'
/home/pi/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/procon_bypass_man-19bc751a490b/lib/procon_bypass_man/support/yaml_writer.rb:6:in `write': undefined method `transform_values' for "fast_return = ProconBypassMan::Plugin::Splatoon2::Macro::FastReturn\nguruguru = ProconBypassMan::Plugin::Splatoon2::Mode::Guruguru\n\ninstall_macro_plugin fast_return\ninstall_macro_plugin ProconBypassMan::Plugin::Splatoon2::Macro::JumpToUpKey\ninstall_macro_plugin ProconBypassMan::Plugin::Splatoon2::Macro::JumpToRightKey\ninstall_macro_plugin ProconBypassMan::Plugin::Splatoon2::Macro::JumpToLeftKey\ninstall_macro_plugin ProconBypassMan::Plugin::Splatoon2::Macro::SokuwariForSplashBomb\ninstall_mode_plugin guruguru\n\nprefix_keys_for_changing_layer [:zr, :zl, :l]\nset_neutral_position 1906, 1886\n\nlayer :up, mode: :manual do\n  # flip :zr, if_pressed: :zr, force_neutral: :zl\n  flip :zr, if_pressed: :zr, force_neutral: :zl\n  flip :zl, if_pressed: [:y, :b, :zl]\n  flip :a, if_pressed: [:a]\n  flip :down, if_pressed: :down\n  macro fast_return.name, if_pressed: [:y, :b, :down]\n  macro ProconBypassMan::Plugin::Splatoon2::Macro::JumpToUpKey, if_pressed: [:y, :b, :up]\n  macro ProconBypassMan::Plugin::Splatoon2::Macro::JumpToRightKey, if_pressed: [:y, :b, :right]\n  macro ProconBypassMan::Plugin::Splatoon2::Macro::JumpToLeftKey, if_pressed: [:y, :b, :left]\n   macro ProconBypassMan::Plugin::Splatoon2::Macro::SokuwariForSplashBomb, if_pressed: [:zl, :right]\n  remap :l, to: :zr\n  left_analog_stick_cap cap: 1100, if_pressed: [:zl, :a], force_neutral: :a\nend\nlayer :right, mode: guruguru.name\nlayer :left do\n  flip :zl, if_pressed: [:y, :b, :zl]\n  flip :a, if_pressed: [:a]\n  flip :down, if_pressed: :down\n  macro fast_return.name, if_pressed: [:y, :b, :down]\n  macro ProconBypassMan::Plugin::Splatoon2::Macro::JumpToUpKey, if_pressed: [:y, :b, :up]\n  macro ProconBypassMan::Plugin::Splatoon2::Macro::JumpToRightKey, if_pressed: [:y, :b, :right]\n  macro ProconBypassMan::Plugin::Splatoon2::Macro::JumpToLeftKey, if_pressed: [:y, :b, :left]\n  remap :l, to: :zr\nend\nlayer :down do\n  # flip :zl\n  # flip :zr, if_pressed: :zr, force_neutral: :zl, flip_interval: \"1F\"\n  remap :l, to: :zr\nend":String (NoMethodError)
```