### PR TITLE
プロコンパフォーマンスのグラフでgc_countを見れるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ bundle install
   * `ActionCable.server.broadcast(device.unique_key, { type: :loaded_config })`
   * `ActionCable.server.broadcast(device.unique_key, { type: :device_is_active })`
       * pingのレスポンス. デバイス詳細画面にあるモーダルのサブミットボタンがクリックできるようになる
+* パフォーマンスモニタリングの数値を書き込む
+
+```ruby
+ProconPerformanceMetric::WriteService.new.execute(
+  timestamp: "2022-07-16 12:21:00+09:00",
+  time_taken_max: "0.168",
+  time_taken_p50: "0.015",
+  time_taken_p95: "0.016",
+  time_taken_p99: "00.24",
+  write_time_max: "0.168",
+  write_time_p50: "0.001",
+  read_time_max: "0.168",
+  read_time_p50: "0.012",
+  interval_from_previous_succeed_max: "0.168",
+  interval_from_previous_succeed_p50: "0.015",
+  read_error_count: "0",
+  write_error_count: "491",
+  load_agv: "0.49-0.5-0.55",
+  gc_count: 3,
+  device_uuid: 'd1',
+  succeed_rate: 1,
+  collected_spans_size: 4422,
+)
+```
 
 ### TODO
 * デバイス詳細ページをReactで作る

--- a/app/controllers/api/procon_performance_metrics_controller.rb
+++ b/app/controllers/api/procon_performance_metrics_controller.rb
@@ -20,6 +20,7 @@ class Api::ProconPerformanceMetricsController < Api::Base
       read_error_count: form.read_error_count,
       write_error_count: form.write_error_count,
       load_agv: form.load_agv,
+      gc_count: form.gc_count,
       device_uuid: device.uuid,
       succeed_rate: form.succeed_rate,
       collected_spans_size: form.collected_spans_size,
@@ -48,6 +49,7 @@ class Api::ProconPerformanceMetricsController < Api::Base
       :read_error_count,
       :write_error_count,
       :load_agv,
+      :gc_count,
       :succeed_rate,
       :collected_spans_size,
     )

--- a/app/controllers/concerns/procon_performance_metric_visualizable.rb
+++ b/app/controllers/concerns/procon_performance_metric_visualizable.rb
@@ -21,6 +21,9 @@ module ProconPerformanceMetricVisualizable
     @bypass_count_data_list = [
       { data: metrics.map { |x| [x.timestamp, x.collected_spans_size] }, name: '合計' },
     ]
+    @gc_count_data_list = [
+      { data: metrics.map { |x| [x.timestamp, x.gc_count] }, name: '合計' },
+    ]
     @load_agv_data_list = [
       { data: metrics.map { |x| [x.timestamp, x.load_agv[0]] }, name: '1分平均' },
       { data: metrics.map { |x| [x.timestamp, x.load_agv[1]] }, name: '5分平均' },

--- a/app/forms/api/create_procon_performance_metric_form.rb
+++ b/app/forms/api/create_procon_performance_metric_form.rb
@@ -1,7 +1,7 @@
 class Api::CreateProconPerformanceMetricForm
   include ActiveModel::Model
 
-  attr_accessor :timestamp, :time_taken_max, :time_taken_p50, :time_taken_p99, :time_taken_p95, :read_error_count, :write_error_count, :load_agv, :interval_from_previous_succeed_max, :interval_from_previous_succeed_p50, :succeed_rate, :collected_spans_size, :write_time_max, :write_time_p50, :read_time_max, :read_time_p50
+  attr_accessor :timestamp, :time_taken_max, :time_taken_p50, :time_taken_p99, :time_taken_p95, :read_error_count, :write_error_count, :load_agv, :interval_from_previous_succeed_max, :interval_from_previous_succeed_p50, :succeed_rate, :collected_spans_size, :write_time_max, :write_time_p50, :read_time_max, :read_time_p50, :gc_count
 
   validates :timestamp, :time_taken_max, :time_taken_p50, :time_taken_p99, :time_taken_p95, :read_error_count, :write_error_count, :load_agv, presence: true
 end

--- a/app/services/procon_performance_metric/base.rb
+++ b/app/services/procon_performance_metric/base.rb
@@ -13,6 +13,7 @@ module ProconPerformanceMetric
                                                    :read_error_count,
                                                    :write_error_count,
                                                    :load_agv,
+                                                   :gc_count,
                                                    :succeed_rate,
                                                    :collected_spans_size)
     def time_taken_max
@@ -68,6 +69,10 @@ module ProconPerformanceMetric
     end
 
     def collected_spans_size
+      super.to_i
+    end
+
+    def gc_count
       super.to_i
     end
 

--- a/app/services/procon_performance_metric/write_service.rb
+++ b/app/services/procon_performance_metric/write_service.rb
@@ -14,6 +14,7 @@ class ProconPerformanceMetric::WriteService < ProconPerformanceMetric::Base
               read_error_count: ,
               write_error_count: ,
               load_agv: ,
+              gc_count: ,
               device_uuid: ,
               succeed_rate: ,
               collected_spans_size: )
@@ -37,6 +38,7 @@ class ProconPerformanceMetric::WriteService < ProconPerformanceMetric::Base
                       read_error_count,
                       write_error_count,
                       load_agv,
+                      gc_count,
                       succeed_rate,
                       collected_spans_size)
 

--- a/app/views/devices/procon_performance_metrics/show.html.erb
+++ b/app/views/devices/procon_performance_metrics/show.html.erb
@@ -33,6 +33,9 @@
   <h2>バイパス回数</h2>
   <%= line_chart @bypass_count_data_list, xtitle: "時間", ytitle: "回数" %>
 
+  <h2>GC回数</h2>
+  <%= line_chart @gc_count_data_list, xtitle: "時間", ytitle: "回数" %>
+
   <h2>ロードアベレージ</h2>
   <%= line_chart @load_agv_data_list, xtitle: "時間", ytitle: "ジョブ数" %>
 <% end %>

--- a/spec/requests/api/procon_performance_metrics_spec.rb
+++ b/spec/requests/api/procon_performance_metrics_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Api::ProconPerformanceMetricsController, type: :request do
           read_error_count: 3,
           write_error_count: 3,
           load_agv: 2,
+          gc_count: 3,
           succeed_rate: 22,
           collected_spans_size: 33,
         }
@@ -44,6 +45,12 @@ RSpec.describe Api::ProconPerformanceMetricsController, type: :request do
         subject
         item = ProconPerformanceMetric::ReadService.new.execute(device_uuid: device.uuid).first
         expect(item.interval_from_previous_succeed_p50).to eq(44)
+      end
+
+      it do
+        subject
+        item = ProconPerformanceMetric::ReadService.new.execute(device_uuid: device.uuid).first
+        expect(item.gc_count).to eq(3)
       end
     end
 

--- a/spec/requests/demo_spec.rb
+++ b/spec/requests/demo_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe "Demo", type: :request do
         read_error_count: 55,
         write_error_count: 6,
         load_agv: "3-3-3",
+        gc_count: 3,
         device_uuid: device.uuid,
         succeed_rate: 0.9,
         collected_spans_size: 300,

--- a/spec/requests/devices/procon_performance_metrics_spec.rb
+++ b/spec/requests/devices/procon_performance_metrics_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Devices::ProconPerformanceMetricsController, type: :request do
         read_error_count: "0",
         write_error_count: "491",
         load_agv: "0.49-0.5-0.55",
+        gc_count: 3,
         device_uuid: 'd1',
         succeed_rate: 1,
         collected_spans_size: 4422,

--- a/spec/services/procon_performance_metric/read_service_spec.rb
+++ b/spec/services/procon_performance_metric/read_service_spec.rb
@@ -20,6 +20,7 @@ describe ProconPerformanceMetric::ReadService do
       read_error_count: 5,
       write_error_count: 6,
       load_agv: "2-3-3",
+      gc_count: 3,
       device_uuid: device_uuid,
       succeed_rate: 0.9,
       collected_spans_size: 300,
@@ -39,6 +40,7 @@ describe ProconPerformanceMetric::ReadService do
       read_error_count: 55,
       write_error_count: 6,
       load_agv: "3.2-3-3",
+      gc_count: 3,
       device_uuid: device_uuid,
       succeed_rate: 0.9,
       collected_spans_size: 300,
@@ -76,5 +78,6 @@ describe ProconPerformanceMetric::ReadService do
     expect(metric2.succeed_rate).to eq(0.9)
     expect(metric2.collected_spans_size).to eq(300)
     expect(metric2.load_agv).to eq([3.2, 3.0, 3.0])
+    expect(metric2.gc_count).to eq(3)
   end
 end

--- a/spec/services/procon_performance_metric/write_service_spec.rb
+++ b/spec/services/procon_performance_metric/write_service_spec.rb
@@ -17,6 +17,7 @@ describe ProconPerformanceMetric::WriteService do
       read_error_count: 3,
       write_error_count: 5,
       load_agv: "2-2-2",
+      gc_count: 3,
       device_uuid: "abc",
     )
   end
@@ -37,6 +38,7 @@ describe ProconPerformanceMetric::WriteService do
       read_error_count: form.read_error_count,
       write_error_count: form.write_error_count,
       load_agv: form.load_agv,
+      gc_count: form.gc_count,
       device_uuid: form.device_uuid,
       succeed_rate: 0.9,
       collected_spans_size: 400,


### PR DESCRIPTION
fix https://github.com/splaplapla/procon_bypass_man_cloud/issues/121