### PR TITLE
[スプラ2,3の自動ドット打ち] ドットが白以外は全部黒として扱う 

### DIFF
--- a/app/services/generate_splatoon2_sketch_binarization_list_service.rb
+++ b/app/services/generate_splatoon2_sketch_binarization_list_service.rb
@@ -1,5 +1,5 @@
 class GenerateSplatoon2SketchBinarizationListService
-  COLOR_BLACK = "black"
+  COLOR_WHITE = "white".freeze
 
   # @param [File] 2値化した画像のファイル
   def initialize(file: )
@@ -11,7 +11,7 @@ class GenerateSplatoon2SketchBinarizationListService
     img = Magick::ImageList.new(@file.open)
     dots = img.rows.times.map { |y|
       img.columns.times.map { |x|
-        img.pixel_color(x, y).to_color == COLOR_BLACK
+        img.pixel_color(x, y).to_color != COLOR_WHITE
       }
     }
   end

--- a/app/services/splatoon2_sketch_service/convert_binarization_image_service.rb
+++ b/app/services/splatoon2_sketch_service/convert_binarization_image_service.rb
@@ -10,7 +10,7 @@ module Splatoon2SketchService
     end
 
     def convert_cmd
-      "convert  -alpha off -threshold #{@threshold}% #{input_file.path} #{output_file.path}"
+      "convert -alpha off -depth 2 -threshold #{@threshold}% #{input_file.path} #{output_file.path}"
     end
   end
 end

--- a/app/services/splatoon2_sketch_service/convert_binarization_image_with_crop_service.rb
+++ b/app/services/splatoon2_sketch_service/convert_binarization_image_with_crop_service.rb
@@ -14,7 +14,7 @@ module Splatoon2SketchService
     private
 
     def convert_cmd
-      "convert #{@crop_arg} -alpha off -threshold #{@threshold}% -resize 320x120! -depth 1 #{input_file.path} #{output_file.path}"
+      "convert #{@crop_arg} -alpha off -depth 2 -resize 320x120 -threshold #{@threshold}% #{input_file.path} #{output_file.path}"
     end
   end
 end


### PR DESCRIPTION
https://github.com/splaplapla/procon_bypass_man_cloud/pull/139 はimagemagic7だと動いていたけど、本番環境で動いている6だとかなり崩れていたので、それっぽく動くようにした。