### PR TITLE
イラスト投稿でのドットの自動打ち画面で、常に書き込みプレビューを表示する

### DIFF
--- a/app/controllers/feature/splatoon2/drawing_sketches_controller.rb
+++ b/app/controllers/feature/splatoon2/drawing_sketches_controller.rb
@@ -12,9 +12,7 @@ class Feature::Splatoon2::DrawingSketchesController < ApplicationController
     @device = get_device
     @dotting_speed = get_dotting_speed
     @flatten_binarization_macros = get_binarization_macros.flatten
-    if params[:debug]
-      @asc_art = get_asc_art
-    end
+    @asc_art = get_asc_art
   end
 
   def create
@@ -43,14 +41,15 @@ class Feature::Splatoon2::DrawingSketchesController < ApplicationController
   end
 
   # @return [Array<Array<String>>]
-  # debug用
   def get_asc_art
     asc_art = nil
+    black_mark = '■'
+    white_mark = '□'
     get_converted_image_file.tap do |converted_image_file|
       list_in_list = GenerateSplatoon2SketchBinarizationListService.new(file: converted_image_file).execute
       asc_art = list_in_list.map { |in_list|
         in_list.map { |item|
-          item ? 'x' : ' '
+          item ? black_mark : white_mark
         }.join
       }.join("<br>").html_safe
     end

--- a/app/views/feature/splatoon2/drawing_sketches/show.html.erb
+++ b/app/views/feature/splatoon2/drawing_sketches/show.html.erb
@@ -40,13 +40,14 @@
 
 <hr>
 
-書き込み対象<br>
+書き込み対象の画像<br>
 
 <img border="1" data-controller="splatoon2-sketches" data-splatoon2-sketches-image-path-value="<%= cropped_monochrome_image_feature_splatoon2_sketch_path(@sketch.id) %>">
 
-<% if @asc_art %>
 <hr>
-<pre>
+
+書き込みプレビュー<br>
+
+<div style='display: block; font-size: 10px; transform: scale(0.6); transform-origin: left top; transform: scale(0.6); width: 2000px; height: 100%; line-height:1'>
 <%= @asc_art %>
-</pre>
-<% end %>
+</div>


### PR DESCRIPTION
今まではdebugというパラメータを付与することで雑な巨大なプレビューを表示していたけど、この修正で、常に表示するようにする。