### PR TITLE
WSサーバ情報を返すAPIを追加する

### DIFF
--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -1,0 +1,11 @@
+class Api::V1::Base < ActionController::Base
+  skip_forgery_protection
+
+  around_action :switch_locale
+
+  def switch_locale(&action)
+    locale = :en
+
+    I18n.with_locale(locale, &action)
+  end
+end

--- a/app/controllers/api/v1/configurations_controller.rb
+++ b/app/controllers/api/v1/configurations_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::ConfigurationsController < Api::V1::Base
+  def show
+    render json: {
+      ws_server_url: "ws://#{request.host}", # TODO: standalone actioncable にする
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,10 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
+    namespace :v1 do
+      resource :configuration, only: [:show]
+    end
+
     resources :events, only: [:create]
     resources :pbm_jobs, only: [:show]
 

--- a/spec/requests/api/v1/configration_spec.rb
+++ b/spec/requests/api/v1/configration_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe Api::V1::ConfigurationsController, type: :request do
+  describe 'GET #show' do
+    subject { get api_v1_configuration_path }
+
+    it do
+      subject
+      expect(response).to be_ok
+      expect(response.body).to eq({ "ws_server_url"=>"ws://www.example.com" }.to_json)
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/splaplapla/procon_bypass_man_cloud/issues/161

cloudrunへ移行しているとwebsocketの接続を維持するのと相性が悪いことがわかった。

クライアント側では、HTTP通信をするサーバと別でwebsocketサーバを参照できるようにしたい。
websocketサーバは、クライアントにハードコードしていると更新がめんどくさいので、サーバ側から返せるようにする。このPRがこれ。
